### PR TITLE
Try to refuse from dispatching sometimes (does not work)

### DIFF
--- a/block/olya-iosched.c
+++ b/block/olya-iosched.c
@@ -18,9 +18,17 @@ static void noop_merged_requests(struct request_queue *q, struct request *rq,
 	list_del_init(&next->queuelist);
 }
 
+int c = 0;
+
 static int noop_dispatch(struct request_queue *q, int force)
 {
 	struct noop_data *nd = q->elevator->elevator_data;
+    
+    if (c++ > 500)
+    {
+        c = 0;
+        return 0;
+    }
 
 	if (!list_empty(&nd->queue)) {
 		struct request *rq;


### PR DESCRIPTION
I was looking to the examples in other schedulers (sfq, deadline). The code works in those schedulers, and sometimes they really refuse to dispatch the queue.
I have made my example as simple as it may be. But it does not work.
Please, help me to understand the situation.

Here is realizations of dispatch queue in [cfq](http://lxr.free-electrons.com/source/block/cfq-iosched.c#L3500) and [deadline](http://lxr.free-electrons.com/source/block/deadline-iosched.c#L243).
