### PR TITLE
dynamic memory for disk names

### DIFF
--- a/block/meta-iosched.c
+++ b/block/meta-iosched.c
@@ -15,13 +15,22 @@ struct queue_arr {
 
 static struct queue_arr all;
 
-static struct gendisk* disks[20];
+static struct gendisk** disks;
 int n_disks = 0;
+int disks_size = 0;
 
-void add_my_disk(struct gendisk* disk) {
-	if (n_disks < 20)
+bool add_my_disk(struct gendisk* disk) {
+	printk("aaaaa, disk %s will be added. N disks: %d\n", disk->disk_name, n_disks);
+	if (disks_size > n_disks) {
 		disks[n_disks++] = disk;
-	printk("aaaaa, disk %s added. N disks: %d\n", disk->disk_name, n_disks);
+		return true;
+	}
+
+	disks = krealloc(disks, (n_disks + 1) * 2 * sizeof(disk), GFP_KERNEL);
+	if (!disks) return false;
+	disks_size = (n_disks + 1) * 2;
+	disks[n_disks++] = disk;
+	return true;
 }
 
 char* get_disk_name(struct request_queue* q) {

--- a/block/meta-iosched.h
+++ b/block/meta-iosched.h
@@ -1,7 +1,7 @@
 #ifndef _META_IOSCHED_H
 #define _META_IOSCHED_H
 
-void add_my_disk(struct gendisk* disk);
+bool add_my_disk(struct gendisk* disk);
 int kobj_init(void);
 
 bool add_queue(struct request_queue *q);


### PR DESCRIPTION
All is fine. System is working.

May be I need to return with -ENOMEM in blk_register_queue() if dynamic allocation failed. But I am not sure because I do not know what the system will do in this situation. Now if something went wrong, one of disks will not be at my list. It is bad, but it is better than crash of whole system.

I haven't found any proofs in documentation why I can allocate the memory here. But I have read code of functions that are called near my function. 
http://lxr.free-electrons.com/source/block/genhd.c?v=4.2#L611
For example, inside this function there is dynamic allocation without any locks. So I concluded that I can do it the same way.
