### PR TITLE
Absolutely fair statistics (does not work)

### DIFF
--- a/block/meta-iosched.c
+++ b/block/meta-iosched.c
@@ -306,9 +306,9 @@ void clean_up(unsigned long unused) {
 		whole_stat -= all.queues[i]->stats[level];
 		spin_unlock(&stat_lock);
 
-		//spin_lock(all.queues[i]->queue_lock); //spin_lock_irq(all.queues[i]->queue_lock);
+		spin_lock(all.queues[i]->queue_lock);
 		all.queues[i]->stats[2] -= all.queues[i]->stats[level];
-		//spin_unlock(all.queues[i]->queue_lock); //spin_unlock_irq(all.queues[i]->queue_lock);
+		spin_unlock(all.queues[i]->queue_lock);
 		all.queues[i]->stats[level] = 0;
 	}
 	group = level;
@@ -321,9 +321,7 @@ void update_stats(struct request_queue *q) {
 	spin_unlock(&stat_lock);
 	q->stats[group]++;
 
-	//spin_lock(q->queue_lock); //spin_lock_irq(q->queue_lock);
 	q->stats[2]++;
-	//spin_unlock(q->queue_lock); //spin_unlock_irq(q->queue_lock);
 }
 
 struct timer_list my_timer;

--- a/block/olya-iosched.c
+++ b/block/olya-iosched.c
@@ -23,6 +23,7 @@ static void noop_merged_requests(struct request_queue *q, struct request *rq,
 
 static int noop_dispatch(struct request_queue *q, int force)
 {
+	struct request *rq;
 	struct noop_data *nd = q->elevator->elevator_data;
 	update_stats(q);
 
@@ -32,7 +33,6 @@ static int noop_dispatch(struct request_queue *q, int force)
 			blk_delay_queue(q, time);
 			return 0;
 		}
-		struct request *rq;
 		rq = list_entry(nd->queue.next, struct request, queuelist);
 		list_del_init(&rq->queuelist);
 		elv_dispatch_sort(q, rq);
@@ -67,11 +67,14 @@ noop_latter_request(struct request_queue *q, struct request *rq)
 	return list_entry(rq->queuelist.next, struct request, queuelist);
 }
 
+bool first_time = true;
+
 static int noop_init_queue(struct request_queue *q, struct elevator_type *e)
 {
 	struct noop_data *nd;
 	struct elevator_queue *eq;
-	if (q->id == 8) {
+	if (first_time) {
+		first_time = false;
 		kobj_init();
 		init_my_timer();
 		init_my_switch_timer();


### PR DESCRIPTION
When I print statistics, I need to have a valid snapshot of all local queue statistics. I have written function for it and it works, but there is 2 places where I need spinlocks on queue. And these two places crashes the system. (They are commented now). 
Every request_queue has its own spinlock. It perfectly suits me.
http://lxr.free-electrons.com/source/block/noop-iosched.c?v=4.2#L80
Here is an example of using. I've tried spin_lock and spin_lock_irq, but both of them does not work. I do not think that I must init queue_lock (it must be already initialized). 

Now q->stats[2] is having whole statistics for this queue. This field can be changed from thread where queue works, and from thread where statistics is refreshing. That's why I need spinlock.
